### PR TITLE
Add support for notion_integration_secret in config file

### DIFF
--- a/scripts/daily_planned_date_review.py
+++ b/scripts/daily_planned_date_review.py
@@ -293,11 +293,13 @@ def main():
     with open(args.config, "r") as f:
         config = yaml.safe_load(f)
 
-    # Get Notion token
+    # Get Notion token (prefer environment variable, fallback to config file)
     NOTION_TOKEN = os.environ.get("NOTION_INTEGRATION_SECRET")
     if NOTION_TOKEN is None:
-        logger.error("NOTION_INTEGRATION_SECRET environment variable not set.")
-        raise EnvironmentError("NOTION_INTEGRATION_SECRET environment variable not set.")
+        NOTION_TOKEN = config.get("notion_integration_secret")
+    if NOTION_TOKEN is None:
+        logger.error("NOTION_INTEGRATION_SECRET not set. Provide via environment variable or notion_integration_secret in config file.")
+        raise EnvironmentError("NOTION_INTEGRATION_SECRET not set. Provide via environment variable or notion_integration_secret in config file.")
 
     # Get active database ID
     ACTIVE_DB_ID = config.get("active_tasks_db_id")

--- a/scripts/template_management/apply_local_template_definitions.py
+++ b/scripts/template_management/apply_local_template_definitions.py
@@ -10,9 +10,12 @@ from utils.notion_client import create_rate_limited_client
 with open("notion_config.yaml", "r") as f:
     config = yaml.safe_load(f)
 
+# Get Notion token (prefer environment variable, fallback to config file)
 NOTION_TOKEN = os.environ.get("NOTION_INTEGRATION_SECRET")
 if NOTION_TOKEN is None:
-    raise EnvironmentError("NOTION_INTEGRATION_SECRET environment variable not set.")
+    NOTION_TOKEN = config.get("notion_integration_secret")
+if NOTION_TOKEN is None:
+    raise EnvironmentError("NOTION_INTEGRATION_SECRET not set. Provide via environment variable or notion_integration_secret in config file.")
 
 DATABASE_ID = config.get("template_tasks_db_id")
 if DATABASE_ID is None:

--- a/scripts/template_management/copy_template_definitions.py
+++ b/scripts/template_management/copy_template_definitions.py
@@ -10,9 +10,12 @@ from utils.notion_client import create_rate_limited_client
 with open("notion_config.yaml", "r") as f:
     config = yaml.safe_load(f)
 
+# Get Notion token (prefer environment variable, fallback to config file)
 NOTION_TOKEN = os.environ.get("NOTION_INTEGRATION_SECRET")
 if NOTION_TOKEN is None:
-    raise EnvironmentError("NOTION_INTEGRATION_SECRET environment variable not set.")
+    NOTION_TOKEN = config.get("notion_integration_secret")
+if NOTION_TOKEN is None:
+    raise EnvironmentError("NOTION_INTEGRATION_SECRET not set. Provide via environment variable or notion_integration_secret in config file.")
 
 DATABASE_ID = config.get("template_tasks_db_id")
 if DATABASE_ID is None:

--- a/scripts/weekly_rollover/create_active_tasks_from_templates.py
+++ b/scripts/weekly_rollover/create_active_tasks_from_templates.py
@@ -330,10 +330,13 @@ def _initialise_from_config(config_path):
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)
 
+    # Prefer environment variable, fallback to config file
     NOTION_TOKEN = os.environ.get("NOTION_INTEGRATION_SECRET")
     if NOTION_TOKEN is None:
-        logger.error("NOTION_INTEGRATION_SECRET environment variable not set.")
-        raise EnvironmentError("NOTION_INTEGRATION_SECRET environment variable not set.")
+        NOTION_TOKEN = config.get("notion_integration_secret")
+    if NOTION_TOKEN is None:
+        logger.error("NOTION_INTEGRATION_SECRET not set. Provide via environment variable or notion_integration_secret in config file.")
+        raise EnvironmentError("NOTION_INTEGRATION_SECRET not set. Provide via environment variable or notion_integration_secret in config file.")
 
     TEMPLATE_DB_ID = config.get("template_tasks_db_id")
     ACTIVE_DB_ID = config.get("active_tasks_db_id")


### PR DESCRIPTION
## Summary
- Add support for `notion_integration_secret` config value in `notion_config.yaml`
- Environment variable `NOTION_INTEGRATION_SECRET` takes precedence for backward compatibility
- Updated all 4 scripts that use the Notion API token

## Test plan
- [x] Verified all 70 unit tests pass
- [ ] Test with secret in config file only (no env var)
- [ ] Test with env var set (should take precedence over config)
- [ ] Test with neither set (should show clear error message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)