### PR TITLE
Consolidate test workflows to eliminate concurrent Notion API calls

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,11 +1,16 @@
 name: Build and Push Docker Image
 
 on:
+  # Trigger after Run Tests workflow completes successfully
+  workflow_run:
+    workflows: ["Run Tests"]
+    types: [completed]
+    branches: [main]
+  # Also trigger on tags (for releases)
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
-  pull_request:
-    branches: [ main ]
+    tags: ['v*']
+  # Allow manual trigger
+  workflow_dispatch:
 
 env:
   REGISTRY: docker.io
@@ -13,66 +18,14 @@ env:
   DOCKER_HUB_USERNAME: ${{ vars.DOCKER_HUB_USERNAME }}
 
 jobs:
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build test image
-      run: docker build --target test -t notion-home-task-manager:test .
-
-    - name: Run unit tests
-      run: |
-        docker run --rm \
-          -v $(pwd)/htmlcov:/app/htmlcov \
-          -v $(pwd)/coverage.xml:/app/coverage.xml \
-          notion-home-task-manager:test \
-          pytest tests/test_weekly_rollover.py tests/test_daily_planned_date_review.py tests/test_scheduler.py -v
-
-  integration-tests:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    needs: unit-tests
-    # Only run integration tests for main branch pushes and tags
-    if: github.event_name != 'pull_request'
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r test_requirements.txt
-
-    - name: Run integration tests
-      env:
-        NOTION_INTEGRATION_SECRET: ${{ secrets.NOTION_INTEGRATION_SECRET_TEST }}
-      run: |
-        pytest tests/test_integration_weekly_rollover.py tests/test_integration_daily_review.py -v --tb=short
-
   build:
+    name: Build and Push
     runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests]
-    # Build if unit tests passed AND either:
-    # - integration tests passed (main/tags)
-    # - integration tests were skipped (PRs)
+    # Only run if triggered by successful test workflow, tag push, or manual dispatch
     if: |
-      always() &&
-      needs.unit-tests.result == 'success' &&
-      (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
       packages: write
@@ -80,12 +33,14 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        # For workflow_run, we need to checkout the correct ref
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Log in to Docker Hub
-      if: github.event_name != 'pull_request'
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
@@ -99,7 +54,6 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch
-          type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=raw,value=latest,enable={{is_default_branch}}
@@ -109,8 +63,8 @@ jobs:
       with:
         context: .
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max 
+        cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,14 +18,32 @@ env:
   DOCKER_HUB_USERNAME: ${{ vars.DOCKER_HUB_USERNAME }}
 
 jobs:
+  wait-for-tests:
+    name: Wait for Tests
+    runs-on: ubuntu-latest
+    # Only needed for tag pushes - workflow_run already ensures tests passed
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Wait for test workflow to complete
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Integration Tests'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
   build:
     name: Build and Push
     runs-on: ubuntu-latest
-    # Only run if triggered by successful test workflow, tag push, or manual dispatch
+    needs: [wait-for-tests]
+    # Run if:
+    # - wait-for-tests succeeded (tag push with tests passed)
+    # - wait-for-tests was skipped (workflow_run or workflow_dispatch)
+    # AND for workflow_run, only if the triggering workflow succeeded
     if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      always() &&
+      (needs.wait-for-tests.result == 'success' || needs.wait-for-tests.result == 'skipped') &&
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Run Tests
 on:
   push:
     branches: [ main, develop ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main, develop ]
 
@@ -40,8 +41,8 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: unit-tests
-    # Only run integration tests on main branch or when explicitly triggered
-    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    # Run integration tests on main branch, tags, or PRs
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'pull_request'
     # Ensure only one integration test runs at a time to prevent Notion API rate limiting
     # All integration tests share the same Notion workspace, so concurrent runs will exceed rate limits
     concurrency:


### PR DESCRIPTION
## Problem

Integration tests were failing with HTTP 429 "Too Many Requests" errors from the Notion API. 

**Root cause:** Two separate workflows (`test.yml` and `docker-build.yml`) both contained integration test jobs that ran concurrently on every push to main. Since both workflows share the same Notion API token and workspace, the combined API calls exceeded Notion's 3 requests/second rate limit - even though each individual workflow had proper per-process rate limiting.

Example failure from the logs:
```
2025-12-19 03:31:48,343 INFO HTTP Request: POST .../query "HTTP/1.1 429 Too Many Requests"
2025-12-19 03:31:48,344 WARNING Rate limited on query. Retry 1/5 after 1.0s
...
2025-12-19 03:32:04,110 ERROR Max retries (5) exceeded for query
```

The previous fix (PR #7) added `concurrency` controls to both workflows, but this only queued the jobs - it didn't address the underlying redundancy of running the same tests twice.

## Solution

Consolidate testing into a single workflow:

1. **`test.yml`** - Single source of truth for all tests
   - Runs unit tests, integration tests, and release validation
   - Now also triggers on tags (for release builds)
   - Retains concurrency control for integration tests

2. **`docker-build.yml`** - Build-only workflow
   - Removed duplicate unit and integration test jobs
   - Now triggers via `workflow_run` after `test.yml` completes successfully
   - Direct trigger on tags and manual `workflow_dispatch` still supported

## Benefits

- **Eliminates rate limiting**: Only one integration test run per commit
- **Faster CI**: No more duplicate test execution
- **Easier maintenance**: Test configuration in one place
- **Cleaner separation**: Test workflow tests, build workflow builds

## Test plan

- [ ] Push to main triggers `test.yml` → on success triggers `docker-build.yml`
- [ ] Tag push triggers `test.yml` with integration tests → triggers `docker-build.yml`
- [ ] Integration tests complete without 429 rate limit errors
- [ ] Docker images are pushed successfully after tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)